### PR TITLE
Update 07 C++ - Threading and Concurrency.md

### DIFF
--- a/C++/07 C++ - Threading and Concurrency.md
+++ b/C++/07 C++ - Threading and Concurrency.md
@@ -167,7 +167,7 @@ std::this_thread::sleep_until(time_point);
 
 **Global Variables**
 
-All global and static variables that are initialised at compile time can be accessed by threads. Since the threads should know the addresses for them.
+All global and static variables that have their memory allocation determined at compile time can be accessed by threads. Since the threads should know the addresses for them.
 
 #### **Passing By Reference**
 


### PR DESCRIPTION
A minor : 
>All global and static variables that are ~~initialised at compile time~~ 
All global and static variables that are initialized at the beginning of execution

maybe, in this context, it seems comprehensive 

> All global and static variables that have their memory allocation determined at compile time can be accessed by threads. Since the threads should know the addresses for them.